### PR TITLE
Wrong generated window id for newly created inventories. (#1784)

### DIFF
--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -58,11 +58,7 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
     }
 
     private static byte generateId() {
-        final byte id = (byte) Math.abs((byte) ID_COUNTER.incrementAndGet());
-        if (id == 0) { // zero is player's inventory id
-            return generateId();
-        }
-        return id;
+        return (byte) ID_COUNTER.updateAndGet(i -> i + 1 >= 128 ? 1 : i + 1);
     }
 
     /**

--- a/src/test/java/net/minestom/server/inventory/InventoryTest.java
+++ b/src/test/java/net/minestom/server/inventory/InventoryTest.java
@@ -78,9 +78,9 @@ public class InventoryTest {
 
     @Test
     public void testIds() {
-        for (int i = 0; i <= 256; ++i) {
-            final Inventory inventory = new Inventory(InventoryType.CHEST_1_ROW, "title");
-            assertTrue(inventory.getWindowId() != 0);
+        for (int i = 0; i <= 1000; ++i) {
+            final byte windowId = new Inventory(InventoryType.CHEST_1_ROW, "title").getWindowId();
+            assertTrue(windowId > 0);
         }
     }
 }


### PR DESCRIPTION
* chore(Inventory): Fixed generated window id sometimes becomes 0 or -128(out of int) which causes empty inventories.

* chore(InventoryTest): Updated inventory window id creation test.

* chore(InventoryTest): Updated inventory window id creation test. (iam's suggestion.)

* chore(Inventory): Updated inventory window id generation that is more thread safe compare to the old one. (iam's suggestion)

* chore(InventoryTest): int window id to byte.